### PR TITLE
Add map exploration state

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,7 +18,16 @@ const choicesEl = document.getElementById('choices');
 
 const player = new Character('勇者', 40, 40, 6, 4);
 let enemy;
-let scene = 0;
+let locationIndex = 0;
+let state = 'map';
+
+const mapData = [
+  { description: 'あなたは旅立ちの村にいる。外に出ますか？' },
+  { description: '森に入った。スライムが現れた！', enemy: { name: 'スライム', hp: 15, maxHp: 15, attack: 3 } },
+  { description: 'さらに奥へ進むとゴブリンが立ち塞がった！', enemy: { name: 'ゴブリン', hp: 20, maxHp: 20, attack: 4 } },
+  { description: 'ボスのドラゴンが現れた！', enemy: { name: 'ドラゴン', hp: 40, maxHp: 40, attack: 6 } },
+  { description: 'ドラゴンを倒した！世界に平和が訪れた...' }
+];
 
 function updateStatus() {
   statusEl.textContent = `あなたのHP: ${player.hp}/${player.maxHp}` + (enemy ? `    ${enemy.name}のHP: ${enemy.hp}` : '');
@@ -43,15 +52,12 @@ function addChoice(text, handler) {
 }
 
 function playerAttack() {
-  if (!enemy || !player.isAlive()) return;
+  if (state !== 'battle' || !enemy || !player.isAlive()) return;
   const dmg = Math.floor(Math.random() * player.attackPower) + 1;
   enemy.hp -= dmg;
   addLog(`あなたの攻撃！${enemy.name}に${dmg}のダメージ！`);
   if (!enemy.isAlive()) {
-    addLog(`${enemy.name}を倒した！`);
-    enemy = null;
-    scene++;
-    nextScene();
+    victory();
   } else {
     enemyAttack();
   }
@@ -59,7 +65,7 @@ function playerAttack() {
 }
 
 function playerHeal() {
-  if (!enemy || !player.isAlive()) return;
+  if (state !== 'battle' || !enemy || !player.isAlive()) return;
   const healAmount = Math.floor(Math.random() * player.healPower) + 1;
   player.hp = Math.min(player.maxHp, player.hp + healAmount);
   addLog(`回復！HPが${healAmount}回復した！`);
@@ -68,7 +74,7 @@ function playerHeal() {
 }
 
 function enemyAttack() {
-  if (!enemy || !enemy.isAlive()) return;
+  if (state !== 'battle' || !enemy || !enemy.isAlive()) return;
   const dmg = Math.floor(Math.random() * 4) + 1;
   player.hp -= dmg;
   addLog(`${enemy.name}の攻撃！あなたは${dmg}のダメージ！`);
@@ -79,37 +85,39 @@ function enemyAttack() {
   }
 }
 
-function nextScene() {
+function victory() {
+  addLog(`${enemy.name}を倒した！`);
+  enemy = null;
+  state = 'map';
+  locationIndex++;
+  showMap();
+}
+
+function showMap() {
+  state = 'map';
   clearChoices();
-  switch(scene) {
-    case 0:
-      addLog('あなたは旅立ちの村にいる。外に出ますか？');
-      addChoice('外に出る', () => { scene++; nextScene(); });
-      break;
-    case 1:
-      addLog('森でスライムが現れた！');
-      enemy = new Character('スライム', 15, 15, 3);
-      addChoice('攻撃', playerAttack);
-      addChoice('回復', playerHeal);
-      break;
-    case 2:
-      addLog('さらに奥へ進むとゴブリンが立ち塞がった！');
-      enemy = new Character('ゴブリン', 20, 20, 4);
-      addChoice('攻撃', playerAttack);
-      addChoice('回復', playerHeal);
-      break;
-    case 3:
-      addLog('ボスのドラゴンが現れた！');
-      enemy = new Character('ドラゴン', 40, 40, 6);
-      addChoice('攻撃', playerAttack);
-      addChoice('回復', playerHeal);
-      break;
-    case 4:
-      addLog('ドラゴンを倒した！世界に平和が訪れた...');
+  const loc = mapData[locationIndex];
+  addLog(loc.description);
+  if (loc.enemy) {
+    addChoice('戦う', () => startBattle(loc.enemy));
+  } else {
+    if (locationIndex < mapData.length - 1) {
+      addChoice('次へ進む', () => { locationIndex++; showMap(); });
+    } else {
       addChoice('もう一度遊ぶ', () => { location.reload(); });
-      break;
+    }
   }
   updateStatus();
 }
 
-nextScene();
+function startBattle(enemyData) {
+  enemy = new Character(enemyData.name, enemyData.hp, enemyData.maxHp, enemyData.attack);
+  state = 'battle';
+  clearChoices();
+  addLog(`${enemy.name}が現れた！`);
+  addChoice('攻撃', playerAttack);
+  addChoice('回復', playerHeal);
+  updateStatus();
+}
+
+showMap();


### PR DESCRIPTION
## Summary
- rework game flow to separate map movement and battle scenes
- manage locations in new `mapData` and handle transitions via `showMap`

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68580f7fcb0483289eee1a2a5ed2bce0